### PR TITLE
Fix POD links, declare non-core prereqs

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -14,6 +14,12 @@ my %WriteMakefileArgs = (
         'ExtUtils::MakeMaker' => '0',
     },
     PREREQ_PM => {
+        'JSON::PP'   => '2.0104',
+        'File::Path' => '2.07',
+        'version'    => '0.77',
+    },
+    TEST_REQUIRES => {
+        'Test::Pod::LinkCheck::Lite' => '0',
     },
     EXE_FILES => ['script/apperlm'],
     dist  => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },
@@ -47,11 +53,23 @@ unless (eval { ExtUtils::MakeMaker->VERSION('6.55_03'); 1 }) {
     @{$WriteMakefileArgs{PREREQ_PM}}{keys %$build_requires} = values %$build_requires;
 }
 
-delete $WriteMakefileArgs{CONFIGURE_REQUIRES}
-    unless eval { ExtUtils::MakeMaker->VERSION('6.52'); 1 };
-delete $WriteMakefileArgs{MIN_PERL_VERSION}
-    unless eval { ExtUtils::MakeMaker->VERSION('6.48'); 1 };
-delete $WriteMakefileArgs{LICENSE}
-    unless eval { ExtUtils::MakeMaker->VERSION('6.31'); 1 };
+my %min_eumm_version = (
+    CONFIGURE_REQUIRES => '6.52',
+    MIN_PERL_VERSION   => '6.48',
+    LICENSE            => '6.31',
+    META_MERGE         => '6.46',
+);
+for my $parameter ( keys %min_eumm_version ) {
+    delete $WriteMakefileArgs{$parameter}
+      unless eval {
+          ExtUtils::MakeMaker->VERSION( $min_eumm_version{$parameter} );
+          1;
+      };
+}
 
 WriteMakefile(%WriteMakefileArgs);
+
+sub MY::postamble {
+    return "authortest: test\n\tAUTHOR_TESTING=1 "
+      . $_[0]->test_via_harness( '$(FULLPERLRUN)', 'xt/author/*.t' );
+}

--- a/lib/Perl/Dist/APPerl.pm
+++ b/lib/Perl/Dist/APPerl.pm
@@ -1,10 +1,10 @@
 package Perl::Dist::APPerl;
 # Copyright (c) 2022 Gavin Hayes, see LICENSE in the root of the project
-use version; our $VERSION = version->declare("v0.1.0");
+use version 0.77; our $VERSION = qv(v0.1.0);
 use strict;
 use warnings;
-use JSON::PP qw(decode_json);
-use File::Path qw(make_path);
+use JSON::PP 2.0104 qw(decode_json);
+use File::Path 2.07 qw(make_path);
 use Cwd qw(abs_path getcwd);
 use Data::Dumper qw(Dumper);
 use File::Basename qw(basename dirname);
@@ -1386,8 +1386,8 @@ chicken-and egg-situation of needing Perl to build APPerl, APPerl may
 be bootstrapped from an existing build of APPerl. See README.md for
 instructions.
 
-Information on the creation of APPerl can be found in this
-L<blogpost|https://computoid.com/posts/Perl-is-Actually-Portable.html>.
+Information on the creation of APPerl can be found in this blog post:
+L<https://computoid.com/posts/Perl-is-Actually-Portable.html>.
 
 =head1 SYNOPSIS
 
@@ -1555,8 +1555,8 @@ builds, skipping the need for building Perl from scratch.
 
 Enter your projects directory, create it if it doesn't exists. Download
 or copy in an existing version of APPerl you wish to build off of.
-Official builds are available on the
-L<APPerl webpage| https://computoid.com/APPerl/>.
+Official builds are available on the APPerl web page:
+L<https://computoid.com/APPerl/>.
 Create a new nobuild APPerl project and build it.
 
   cd projectdir
@@ -1689,20 +1689,20 @@ Build and test it.
 
 =head1 SUPPORT AND DOCUMENTATION
 
-L<APPerl webpage|https://computoid.com/APPerl/>
+APPerl web page: L<https://computoid.com/APPerl/>
 
 Support and bug reports can be found at the repository
-L<https://github.com/G4Vi/APPerl>
+L<https://github.com/G4Vi/Perl-Dist-APPerl>
 
 =head1 ACKNOWLEDGEMENTS
 
-The L<Cosmopolitan Libc|https://github.com/jart/cosmopolitan>
-contributors, especially L<Justine Tunney|https://justine.lol/> and
-L<Gautham Venkatasubramanian|https://ahgamut.github.io>. APPerl
+The Cosmopolitan Libc (L<https://github.com/jart/cosmopolitan>)
+contributors, especially Justine Tunney (L<https://justine.lol/>) and
+Gautham Venkatasubramanian (L<https://ahgamut.github.io>). APPerl
 wouldn't be possible without Actually Portable Executables and
 polyfills of several Linux and POSIX APIs for other platforms.
-Gautham's
-L<Python port|https://ahgamut.github.io/2021/07/13/ape-python/>
+Gautham's Python port
+(L<https://ahgamut.github.io/2021/07/13/ape-python/>)
 inspired this project.
 
 =head1 AUTHOR

--- a/xt/author/pod_linkcheck.t
+++ b/xt/author/pod_linkcheck.t
@@ -1,0 +1,9 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use Test::Pod::LinkCheck::Lite;
+
+Test::Pod::LinkCheck::Lite->new->all_pod_files_ok('.');
+done_testing();


### PR DESCRIPTION
I noted that one of the POD links to the GitHub repo was incorrect, so I fixed that and dutifully added an author test (which can be run with `make authortest`). Note that checking HTTPS scheme URLs and uninstalled modules via CPAN Meta DB requires the installation of Net::SSLeay and IO::Socket::SSL; I've opened trwyant/perl-Test-Pod-LinkCheck-Lite#2 to get that resolved.

That led me down a rabbit hole of making sure this could build, test, and install on Perl 5.10 as declared in the Makefile.PL. There were a couple of issues:

1. URL links in POD didn't gain support for displaying text instead of the bare URL until Perl 5.12. So I adjusted the POD to use unlinked text with the links adjacent.
2. Some core Perl module dependencies either weren't core at that time (JSON::PP) or lacked features (File::Path's `make_path` function, version's `declare` method). So I added explicit version requirements for both that contain the required functions.

Also, just for completeness' sake, I adjusted the Makefile.PL to skip the META_MERGE Makefile argument on older versions of ExtUtils::MakeMaker.